### PR TITLE
Add association to models and pagination to index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem 'turbolinks'
 gem 'uglifier', '>= 1.3.0'
 
 gem 'bcrypt', '~> 3.1.7'
+gem 'foreigner', '~> 1.6.1'
+gem 'kaminari', '~> 0.15.1'
 gem 'nokogiri', '~> 1.6.1'
 gem 'rails-i18n', '~> 4.0.1'
 gem 'therubyracer',  platforms: :ruby
@@ -37,6 +39,7 @@ group :development, :test do
   gem 'hirb-unicode'
   gem 'pry-byebug'
   gem 'pry-rails'
+  gem 'quiet_assets', '~> 1.0.2'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,8 @@ GEM
     factory_girl_rails (4.4.1)
       factory_girl (~> 4.4.0)
       railties (>= 3.0.0)
+    foreigner (1.6.1)
+      activerecord (>= 3.0.0)
     hike (1.2.3)
     hirb (0.7.3)
     hirb-unicode (0.0.5)
@@ -78,6 +80,9 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.6)
+    kaminari (0.15.1)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     libv8 (3.16.14.19)
     mail (2.5.4)
       mime-types (~> 1.16)
@@ -100,6 +105,8 @@ GEM
       pry (~> 0.10)
     pry-rails (0.3.6)
       pry (>= 0.10.4)
+    quiet_assets (1.0.3)
+      railties (>= 3.1, < 5.0)
     rack (1.5.5)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -203,15 +210,18 @@ DEPENDENCIES
   coffee-rails (~> 4.0.0)
   database_cleaner (~> 1.2.0)
   factory_girl_rails (~> 4.4.1)
+  foreigner (~> 1.6.1)
   hirb
   hirb-unicode
   html2slim
   jbuilder (~> 2.0)
   jquery-rails
+  kaminari (~> 0.15.1)
   mysql2 (= 0.3.13)
   nokogiri (~> 1.6.1)
   pry-byebug
   pry-rails
+  quiet_assets (~> 1.0.2)
   rails (= 4.1.0)
   rails-i18n (~> 4.0.1)
   rake (< 11.0)

--- a/app/assets/stylesheets/admin/pagination.css.scss
+++ b/app/assets/stylesheets/admin/pagination.css.scss
@@ -1,0 +1,33 @@
+@import 'colors';
+@import 'dimensions';
+
+nav.pagination {
+  margin: $moderate 0;
+  padding: $moderate 0;
+  display: inline-block;
+  border-top: solid $very_light_gray 1px;
+  border-bottom: solid $very_light_gray 1px;
+
+  .page, .first, .last, .prev, .next {
+    display: inline-block;
+    background-color: $light_gray;
+    padding: $narrow $moderate;
+
+    a {
+      text-decoration: none;
+    }
+  }
+
+  .current {
+    background-color: $dark_gray;
+    color: $light_gray;
+  }
+
+  .disabled {
+    color: $gray;
+  }
+
+  .gap {
+    background-color: transparent;
+  }
+}

--- a/app/controllers/admin/staff_events_controller.rb
+++ b/app/controllers/admin/staff_events_controller.rb
@@ -1,0 +1,11 @@
+class Admin::StaffEventsController < Admin::Base
+  def index
+    if params[:staff_member_id]
+      @staff_member = StaffMember.find(params[:staff_member_id])
+      @events = @staff_member.events
+    else
+      @events = StaffEvent
+    end
+    @events = @events.order(occurred_at: :desc).includes(:member).page(params[:page])
+  end
+end

--- a/app/controllers/admin/staff_members_controller.rb
+++ b/app/controllers/admin/staff_members_controller.rb
@@ -2,7 +2,7 @@ class Admin::StaffMembersController < Admin::Base
   before_action :set_staff_member, only: %i(show edit update destroy)
 
   def index
-    @staff_members = StaffMember.order(:family_name_kana, :given_name_kana)
+    @staff_members = StaffMember.order(:family_name_kana, :given_name_kana).page(params[:page])
   end
 
   def show

--- a/app/controllers/staff/sessions_controller.rb
+++ b/app/controllers/staff/sessions_controller.rb
@@ -15,6 +15,7 @@ class Staff::SessionsController < Staff::Base
     if @form.email.present?
       staff_member = StaffMember.find_by(email_for_index: @form.email.downcase)
       if staff_member.suspended
+        staff_member.events.create!(type: 'rejected')
         flash.now.alert = 'アカウントが停止されています'
         render action: 'new' and return
       end
@@ -22,6 +23,7 @@ class Staff::SessionsController < Staff::Base
     if Staff::Authenticator.new(staff_member).authenticate(@form.password)
       session[:staff_member_id] = staff_member.id
       session[:last_access_at] = Time.current
+      staff_member.events.create!(type: 'logged_in')
       flash.notice = 'ログインしました'
       redirect_to :staff_root
     else
@@ -31,6 +33,7 @@ class Staff::SessionsController < Staff::Base
   end
 
   def destroy
+    current_staff_member.events.create!(type: 'logged_out') if current_staff_member
     session.delete(:staff_member_id)
     flash.notice = 'ログアウトしました'
     redirect_to :staff_root

--- a/app/models/staff_event.rb
+++ b/app/models/staff_event.rb
@@ -1,0 +1,16 @@
+class StaffEvent < ActiveRecord::Base
+  self.inheritance_column = nil
+
+  belongs_to :member, class_name: 'StaffMember', foreign_key: 'staff_member_id'
+  alias_attribute :occurred_at, :created_at
+
+  DESCRIPTIONS = {
+    logged_in: 'ログイン',
+    logged_out: 'ログアウト',
+    rejected: 'ログイン拒否'
+  }
+
+  def description
+    DESCRIPTIONS[type.to_sym]
+  end
+end

--- a/app/models/staff_member.rb
+++ b/app/models/staff_member.rb
@@ -1,4 +1,6 @@
 class StaffMember < ActiveRecord::Base
+  has_many :events, class_name: 'StaffEvent', dependent: :destroy
+
   before_validation do
     # PostgreSQL doesn't recognize the difference of up/downcase.
     # Having unique restriction as well as index option,
@@ -18,5 +20,9 @@ class StaffMember < ActiveRecord::Base
     !suspended? &&
     start_date <= Date.today &&
     (end_date.nil? || Date.today < end_date)
+  end
+
+  def full_name
+    family_name + given_name
   end
 end

--- a/app/views/admin/staff_events/_event.html.slim
+++ b/app/views/admin/staff_events/_event.html.slim
@@ -1,0 +1,9 @@
+tr
+  - unless @staff_member
+    td
+      = link_to event.member.family_name + event.member.given_name, [:admin, event.member, :staff_events]
+
+  td
+    = event.description
+  td.date
+    = event.occurred_at.strftime('%Y/%m/%d %H:%M:%S')

--- a/app/views/admin/staff_events/index.html.slim
+++ b/app/views/admin/staff_events/index.html.slim
@@ -1,0 +1,30 @@
+- if @staff_member
+  - @title = "#{@staff_member.full_name}さんのログイン・ログアウト履歴"
+- else
+  - @title = '職員のログイン・ログアウト履歴'
+
+h1
+  = @title
+
+.table-wrapper
+  .links
+    = link_to '職員一覧', :admin_staff_members
+
+  = paginate @events
+
+  table.listing
+    tr
+      - unless @staff_member
+        th 氏名
+      th 種別
+      th 日時
+
+    = render partial: 'event', collection: @events
+
+    - if @events.empty?
+      tr= content_tag(:td, '記録がありません', colspan: @staff_member ? 2 : 3, style: 'text-align: center;')
+
+  = paginate @events
+
+  .links
+    = link_to '職員一覧', :admin_staff_members

--- a/app/views/admin/staff_members/_staff_member.html.slim
+++ b/app/views/admin/staff_members/_staff_member.html.slim
@@ -15,4 +15,5 @@ tr
     = m.suspended ? raw('&#x2611') : raw('&#x2610')
   td.actions
     => link_to '編集', [:edit, :admin, m]
-    =< link_to '削除', [:admin, m], method: :delete, data: { confirm: '本当に削除しますか？' }
+    => link_to 'Events', [:admin, m, :staff_events]
+    => link_to '削除', [:admin, m], method: :delete, data: { confirm: '本当に削除しますか？' }

--- a/app/views/admin/staff_members/index.html.slim
+++ b/app/views/admin/staff_members/index.html.slim
@@ -7,6 +7,8 @@ h1
   .links
     = link_to '新規登録', :new_admin_staff_member
 
+  = paginate @staff_members
+
   table.listing
     tr
       th 氏名
@@ -21,3 +23,5 @@ h1
 
   .links
     = link_to '新規登録', :new_admin_staff_member
+
+  = paginate @staff_members

--- a/app/views/admin/top/dashboard.html.slim
+++ b/app/views/admin/top/dashboard.html.slim
@@ -4,5 +4,5 @@ h1
   = @title
 
 ul.manu
-  li
-    = link_to '職員管理', :admin_staff_members
+  li= link_to '職員管理', :admin_staff_members
+  li= link_to '職員のログイン・ログアウト履歴', :admin_staff_events

--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -1,0 +1,5 @@
+span.first
+  - unless current_page.first?
+    = link_to t('views.pagination.first').html_safe, url
+  - else
+    = content_tag(:span, t('views.pagination.first'), class: 'disabled')

--- a/app/views/kaminari/_gap.html.slim
+++ b/app/views/kaminari/_gap.html.slim
@@ -1,0 +1,2 @@
+span.page.gap
+  == t('views.pagination.truncate').html_safe

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -1,0 +1,5 @@
+span.last
+  - unless current_page.last?
+    = link_to t('views.pagination.last').html_safe, url
+  - else
+    = content_tag(:span, t('views.pagination.last'), class: 'disabled')

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -1,0 +1,5 @@
+span.next
+  - unless current_page.last?
+    = link_to t('views.pagination.next').html_safe, url
+  - else
+    = content_tag(:span, t('views.pagination.next'), class: 'disabled')

--- a/app/views/kaminari/_page.html.slim
+++ b/app/views/kaminari/_page.html.slim
@@ -1,0 +1,2 @@
+span class="page#{' current' if page.current?}"
+  == link_to_unless page.current?, page, url, {:remote => remote, :rel => page.next? ? 'next' : page.prev? ? 'prev' : nil}

--- a/app/views/kaminari/_paginator.html.slim
+++ b/app/views/kaminari/_paginator.html.slim
@@ -1,0 +1,11 @@
+== paginator.render do
+  nav.pagination
+    == first_page_tag
+    == prev_page_tag
+    - each_page do |page|
+      - if page.left_outer? || page.right_outer? || page.inside_window?
+        == page_tag page
+      - elsif !page.was_truncated?
+        == gap_tag
+    == next_page_tag
+    == last_page_tag

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -1,0 +1,5 @@
+span.prev
+  - unless current_page.first?
+    = link_to t('views.pagination.previous').html_safe, url
+  - else
+    = content_tag(:span, t('views.pagination.previous'), class: 'disabled')

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,10 @@
+Kaminari.configure do |config|
+  config.default_per_page = 20
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+end

--- a/config/locales/views/paginate.ja.yml
+++ b/config/locales/views/paginate.ja.yml
@@ -1,0 +1,8 @@
+ja:
+  views:
+    pagination:
+      first: '先頭'
+      last: '末尾'
+      previous: '前'
+      next: '次'
+      truncate: '...'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,10 @@ Rails.application.routes.draw do
     namespace :admin, path: config[:admin][:path] do
       get       'login' => 'sessions#new', as: :login
       resource  :session, only: %i(create destroy)
-      resources :staff_members, path: 'staff'
+      resources :staff_members, path: 'staff' do
+        resources :staff_events, only: :index
+      end
+      resources :staff_events, only: :index
       root 'top#index'
     end
   end

--- a/db/migrate/20170418045712_create_staff_events.rb
+++ b/db/migrate/20170418045712_create_staff_events.rb
@@ -1,0 +1,13 @@
+class CreateStaffEvents < ActiveRecord::Migration
+  def change
+    create_table :staff_events do |t|
+      t.references :staff_member, null: false
+      t.string     :type,         null: false
+      t.datetime   :created_at,   null: false
+    end
+
+    add_index :staff_events, :created_at
+    add_index :staff_events, %i(staff_member_id created_at)
+    add_foreign_key :staff_events, :staff_members
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170409072640) do
+ActiveRecord::Schema.define(version: 20170418045712) do
 
   create_table "administrators", force: true do |t|
     t.string   "email"
@@ -23,6 +23,15 @@ ActiveRecord::Schema.define(version: 20170409072640) do
   end
 
   add_index "administrators", ["email_for_index"], name: "index_administrators_on_email_for_index", unique: true, using: :btree
+
+  create_table "staff_events", force: true do |t|
+    t.integer  "staff_member_id", null: false
+    t.string   "type",            null: false
+    t.datetime "created_at",      null: false
+  end
+
+  add_index "staff_events", ["created_at"], name: "index_staff_events_on_created_at", using: :btree
+  add_index "staff_events", ["staff_member_id", "created_at"], name: "index_staff_events_on_staff_member_id_and_created_at", using: :btree
 
   create_table "staff_members", force: true do |t|
     t.string   "email",                            null: false
@@ -41,5 +50,7 @@ ActiveRecord::Schema.define(version: 20170409072640) do
 
   add_index "staff_members", ["email_for_index"], name: "index_staff_members_on_email_for_index", unique: true, using: :btree
   add_index "staff_members", ["family_name_kana", "given_name_kana"], name: "index_staff_members_on_family_name_kana_and_given_name_kana", using: :btree
+
+  add_foreign_key "staff_events", "staff_members", name: "staff_events_staff_member_id_fk"
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,4 @@
-table_names = %w( staff_members administrators )
+table_names = %w(staff_members administrators staff_events)
 table_names.each do |table_name|
   path = Rails.root.join('db', 'seeds', Rails.env, "#{table_name}.rb")
   if File.exist?(path)

--- a/db/seeds/development/staff_events.rb
+++ b/db/seeds/development/staff_events.rb
@@ -1,0 +1,17 @@
+staff_members = StaffMember.all
+
+256.times do |n|
+  member = staff_members.sample
+  event = member.events.build
+  if member.active?
+    if n.even?
+      event.type = 'logged_in'
+    else
+      event.type = 'logged_out'
+    end
+  else
+    event.type = 'rejected'
+  end
+  event.occurred_at = (256 - n).hours.ago
+  event.save!
+end

--- a/spec/models/staff_event_spec.rb
+++ b/spec/models/staff_event_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe StaffEvent, :type => :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## WHAT
- 管理者がログイン情報管理をできるようにする
- モデルのアソシエーションを追加する
- 管理者画面にページネーションを追加する

## WHY
- ログイン情報を一元的に把握できるようにするため
- モデルを越境した処理を可能にするため
- レコードが増えても使いやすいインターフェースを担保するため